### PR TITLE
Avoiding indexOf() operation on list, instead using sets.

### DIFF
--- a/src/cl/uchile/dcc/facet/core/CacheBuilder.java
+++ b/src/cl/uchile/dcc/facet/core/CacheBuilder.java
@@ -41,6 +41,8 @@ public class CacheBuilder {
             if(frequency > M_PRIME)
                 map.put(poCode, frequency);
         }
+        
+        System.out.println(read+" PO values processed in total.");
         return map.entrySet().stream()
                 .sorted((e1, e2) -> e2.getValue().compareTo(e1.getValue()))
                 .map(Map.Entry::getKey)


### PR DESCRIPTION
Not tested but should speed up caching detection by avoiding indexOf(.) ops on lists. Instead uses sets.